### PR TITLE
Update the GA profile name used

### DIFF
--- a/analytics_fetcher/ga_client.py
+++ b/analytics_fetcher/ga_client.py
@@ -83,7 +83,7 @@ class GAClient(object):
             self.profiles = {
                 'search': get_profile(
                     self.service, 'www.gov.uk', 'UA-26179049-1',
-                    'X. GOV.UK (Entire site - Search analysis)'),
+                    'Q. Site search (entire site with query strings)'),
             }
         except AccessTokenRefreshError:
             logger.exception(


### PR DESCRIPTION
The profile name has been updated to fit in with policy, so this code
needs updating to find the profile using the new name.
