### PR TITLE
Bump distribute version to latest release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 argparse==1.2.1
-distribute==0.6.24
+distribute==0.7.3
 gapy==1.3.0
 google-api-python-client==1.0
 httplib2==0.8


### PR DESCRIPTION
The older version of distribute failed on our Jenkins boxes, which are
running a fairly old version of pip, because they tried to patch the
installed version of pip and ended up introducing a reference to
an undefined variable.  (NameError: name 'install' is not defined)

This is fixed by upgrading to a newer version of distribute.
