### PR TITLE
Use random node for running commands

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -3,9 +3,10 @@ if [ \! -d ENV ]; then virtualenv ENV; fi
 pip install -r requirements.txt
 rm -f page-traffic.dump
 PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
-ssh deploy@search-1.api '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/bulk_load page-traffic)' < page-traffic.dump
-ssh deploy@search-1.api '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-ssh deploy@search-1.api '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-ssh deploy@search-1.api '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-ssh deploy@search-1.api '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=service-manual govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-ssh deploy@search-1.api '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'
+SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/bulk_load page-traffic)' < page-traffic.dump
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:migrate_index)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:migrate_index)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:migrate_index)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=service-manual govuk_setenv rummager bundle exec rake rummager:migrate_index)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; SKIP_LINKS_INDEXING_TO_PREVENT_TIMEOUTS=1 RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'


### PR DESCRIPTION
The nightly-run script should use a random node rather than relying on `search-1`. This will help us uncover misconfigurations more quickly and means we're more likely to have reliable infrastructure.

(Note that I haven't tested this change.)