### PR TITLE
Remove service-manual from indexes

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -8,5 +8,4 @@ ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle 
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:migrate_index)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:migrate_index)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=service-manual govuk_setenv rummager bundle exec rake rummager:migrate_index)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'


### PR DESCRIPTION
The service-manual index is being removed (https://trello.com/c/w9RIW7qz).