### PR TITLE
Add missing shebang to nightly-run.sh

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 set -o pipefail
 


### PR DESCRIPTION
Without it, jenkins uses the default shell (dash?) which doesn't know
about pipefail.