### PR TITLE
Re-enable nightly job

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-#set -e
-#set -o pipefail
-#
-#if [ \! -d ENV ]; then virtualenv ENV; fi
-#. ENV/bin/activate
-#pip install -r requirements.txt
-#rm -f page-traffic.dump
-#PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
-#SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
-#ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/bulk_load page-traffic)' < page-traffic.dump
-#ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-#ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-#ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-#ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'
+set -e
+set -o pipefail
+
+if [ \! -d ENV ]; then virtualenv ENV; fi
+. ENV/bin/activate
+pip install -r requirements.txt
+rm -f page-traffic.dump
+PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
+SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/bulk_load page-traffic)' < page-traffic.dump
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:migrate_index)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:migrate_index)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:migrate_index)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'


### PR DESCRIPTION
Re-enable the job which fetches page traffic from Google Analytics and uses to update the popularity figures in the search indexes.

This was temporarily disabled because of a bug in the reindexing process which replaced the Elasticsearch document `_type` values with the default value. That bug has now been fixed, so this job is safe to re-enable.

https://trello.com/c/npsstuyq/103-elasticsearch-document-type-is-wrong-for-specialist-documents