### PR TITLE
Temporarily disable index cleanup

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -12,4 +12,4 @@ ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle 
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:migrate_index)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:migrate_index)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:migrate_index)'
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'
+# ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'


### PR DESCRIPTION
This is a safety measure as we deploy the latest code
around removing _id and _type from the main content.

This change should be revert and the rake task run manually
tomorrow.