### PR TITLE
Add a flag for update_popularity processing

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -12,7 +12,7 @@ ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle 
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:migrate_index)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; LOG_FAILED_LINKS_LOOKUP_AND_CONTINUE=1 RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:migrate_index)'
 
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:update_popularity)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=govuk govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec rake rummager:sync_govuk)'
 


### PR DESCRIPTION
This flag means that all data in the index is processed
and not just migrated format which is the default.

https://trello.com/c/IeU8rFj3/293-switch-indexes-to-use-update-popularity-instead-of-bulk-update