### PR TITLE
Specify version of cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 argparse==1.2.1
+cryptography==2.0.3
 distribute==0.7.3
 gapy==1.3.0
 google-api-python-client==1.0


### PR DESCRIPTION
The cryptography library is required by the pyOpenSSL dependency, which specifies a cryptography version of >=0.2.1. A recent release of cryptography (version 2.1) broke the dependency installation because it required a more recent version of Python setuptools than is installed on our machines. Python is not managed by puppet, so it wasn't simple to just upgrade setuptools.

Fixing the cryptography version to a slightly older one (2.0.3) fixes the installation issue. This should ideally be a temporary patch - this project is old and unmaintained, and it would be better to upgrade its dependencies or possibly rewrite it in a language which has better support on GOV.UK.

https://trello.com/c/qysihuHY/360-python-version-errors-in-overnight-popularity-job

Mob-debugged with @Rosa-Fox and @brenetic 