### PR TITLE
Run migrate_schema task overnight

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -10,10 +10,10 @@ PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
 SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/page_traffic_load)' < page-traffic.dump
 
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:update_popularity)'
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:update_popularity)'
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:update_popularity)'
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=govuk govuk_setenv rummager bundle exec rake rummager:update_popularity)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=mainstream CONFIRM_INDEX_MIGRATION_START=true govuk_setenv rummager bundle exec rake rummager:migrate_schema)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed CONFIRM_INDEX_MIGRATION_START=true govuk_setenv rummager bundle exec rake rummager:migrate_schema)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government CONFIRM_INDEX_MIGRATION_START=true govuk_setenv rummager bundle exec rake rummager:migrate_schema)'
+ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=govuk CONFIRM_INDEX_MIGRATION_START=true govuk_setenv rummager bundle exec rake rummager:migrate_schema)'
 
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec rake rummager:sync_govuk)'
 


### PR DESCRIPTION
[Trello](https://trello.com/c/7XlHiC7T/361-make-search-ignore-diacritics)

- Run migrate_schema task overnight so that asciifolding filters will be applied
- Will change this back tomorrow!
- Will add a task to the backlog to split reindexing code out of Rummager's `PopularityUpdater` and into its own class.