### PR TITLE
Remove "clean" step, and temporarily disable job

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-set -e
-set -o pipefail
-
-if [ \! -d ENV ]; then virtualenv ENV; fi
-. ENV/bin/activate
-pip install -r requirements.txt
-rm -f page-traffic.dump
-PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
-SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/page_traffic_load)' < page-traffic.dump
-
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:update_popularity)'
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:update_popularity)'
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:update_popularity)'
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=govuk govuk_setenv rummager bundle exec rake rummager:update_popularity)'
-
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec rake rummager:sync_govuk)'
+# set -e
+# set -o pipefail
+#
+# if [ \! -d ENV ]; then virtualenv ENV; fi
+# . ENV/bin/activate
+# pip install -r requirements.txt
+# rm -f page-traffic.dump
+# PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
+# SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
+# ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/page_traffic_load)' < page-traffic.dump
+#
+# ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:update_popularity)'
+# ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:update_popularity)'
+# ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:update_popularity)'
+# ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=govuk govuk_setenv rummager bundle exec rake rummager:update_popularity)'
+#
+# ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec rake rummager:sync_govuk)'

--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -16,5 +16,3 @@ ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGE
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=govuk govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec rake rummager:sync_govuk)'
-
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=all govuk_setenv rummager bundle exec rake rummager:clean)'


### PR DESCRIPTION
- Remove now-irrelevant index cleanup step

  The `rummager:clean` rake task deletes old indices, leaving only the indices which currently have the alias. This step was necessary when the popularity update job created a brand new index every night. The job now updates the popularity values in place, so this deletion step is no longer necessary.

  Worse, the deletion step sometimes deletes old indexes that would be useful to keep around for a day or two in case we want to switch back to an old version of the index because there were problems in the overnight job.

  In the future, if someone creates a new index manually they will also have to delete the old index manually (e.g. by running the rake task in Jenkins).

-  Temporarily disable popularity update job

  Prevent the popularity update from running overnight while we investigate the root cause of an incident which may have been caused by this job.