### PR TITLE
Allow traffic load to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This code extracts analytics data from google analytics and processes it such
 that it can be used by the site search on gov.uk for improving search result
 quality.
 
-
 Installation
 ------------
 
@@ -45,7 +44,7 @@ but in summary:
  - Run the following command to generate the refresh token.
 
        PYTHONPATH=. python scripts/setup_auth.py /path/to/client_secrets.json
- 
+
    It will display a url which you'll need to open with a browser that's signed
    in to the google account that the client JSON was downloaded from; paste the
    result into the prompt.  The command will output (to stdout) a "GAAUTH"
@@ -80,3 +79,15 @@ in a directory "cache" at the top level of a checkout.  The location of the
 cache can be controlled by passing a path in the `CACHE_DIR` environment
 variable.  Entries which are older than 30 days will be removed from the cache
 at the end of each run of the fetch script.
+
+Running popularity update without retrieving GA data
+----------------------------------------------------
+
+When running the full script on integration and staging it is desirable that
+we don't retrieve new data from GA.
+
+This can be achieved with the following command:
+
+```bash
+./nightly-run.sh SKIP_TRAFFIC_LOAD=true
+```

--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -2,13 +2,15 @@
 set -e
 set -o pipefail
 
-if [ \! -d ENV ]; then virtualenv ENV; fi
-. ENV/bin/activate
-pip install -r requirements.txt
-rm -f page-traffic.dump
-PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
-SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/page_traffic_load)' < page-traffic.dump
+if [ -z $SKIP_TRAFFIC_LOAD ]; then
+  if [ \! -d ENV ]; then virtualenv ENV; fi
+  . ENV/bin/activate
+  pip install -r requirements.txt
+  rm -f page-traffic.dump
+  PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
+  SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
+  ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/page_traffic_load)' < page-traffic.dump
+fi
 
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:update_popularity)'


### PR DESCRIPTION
We want to be able to run this process on staging and
integration without doing the data download from GA.

Passing in the `SKIP_TRAFFIC_LOAD` will allow us to do this

https://trello.com/c/3VkbdYrB/456-test-nightly-popularity-rebuild-on-integration-and-staging