### PR TITLE
Clean up page traffic index

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -10,6 +10,7 @@ if [[ -z $SKIP_TRAFFIC_LOAD ]]; then
   rm -f page-traffic.dump
   PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
   ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec ./bin/page_traffic_load)' < page-traffic.dump
+  ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec rake rummager:clean RUMMAGER_INDEX=page-traffic'
 fi
 
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:update_popularity)'


### PR DESCRIPTION
We create a new page traffic index each night as part of the popularity update,
this used to be deleted as part of the nightly tasks, however we have disabled
the blanket delete so we don't remove backup indices.

This code will re-enable the delete for the page-traffic index only.

https://trello.com/c/OBhgB1Lw/531-code-tidy-up