### PR TITLE
Don't update popularity for the mainstream index

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -13,7 +13,6 @@ if [[ -z $SKIP_TRAFFIC_LOAD ]]; then
   ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec rake rummager:clean RUMMAGER_INDEX=page-traffic)'
 fi
 
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=mainstream govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=govuk govuk_setenv rummager bundle exec rake rummager:update_popularity)'


### PR DESCRIPTION
Mainstream is no longer used and will be deleted soon

See https://github.com/alphagov/rummager/pull/1135
Trello: https://trello.com/c/LiapHutO/553-remove-reference-to-mainstream-index