### PR TITLE
Remove govuk sync step

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -17,5 +17,3 @@ ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGE
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv rummager bundle exec rake rummager:update_popularity)'
 ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; RUMMAGER_INDEX=govuk govuk_setenv rummager bundle exec rake rummager:update_popularity)'
-
-ssh deploy@${SEARCH_NODE} '(cd /var/apps/rummager; govuk_setenv rummager bundle exec rake rummager:sync_govuk)'


### PR DESCRIPTION
paired with @suzannehamilton

All the data in mainstream has been migrated to the govuk index so 
we no longer need to sync data between the two.

The removed line also caused an error because the rake task
was recently changed: https://github.com/alphagov/rummager/pull/1135