### PR TITLE
Change the virtualenv to use custom Python in /opt

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
 if [[ -z $SKIP_TRAFFIC_LOAD ]]; then
-  if [ \! -d ENV ]; then virtualenv ENV; fi
+  if [ \! -d ENV ]; then virtualenv -p /opt/python2.7/bin/python ENV; fi
   . ENV/bin/activate
   pip install -r requirements.txt
   rm -f page-traffic.dump


### PR DESCRIPTION
- The current version of Python in Trusty 2.7.6 does not support SSL
  in httplib2 anymore.

- We added a custom compiled Python 2.7.14 + Setuptools + Pip in
  /opt/python2.7

- This change will make the virtualenv use it.

@schmie