### PR TITLE
Update google-api-python-client and httplib2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 argparse==1.2.1
 cryptography==2.0.3
 distribute==0.7.3
-gapy==1.3.0
-google-api-python-client==1.0
-httplib2==0.8
+gapy==1.3.6
+google-api-python-client==1.4.2
+httplib2==0.11.3
+oauth2client==1.5.2
 mock==1.0.1
 py==1.4.20
-pyOpenSSL==0.14
+pyOpenSSL==17.0.0
 pytest==2.5.2
 python-gflags==2.0
 requests==2.2.1


### PR DESCRIPTION
- The nightly-run.sh script as run in production Jenkins is failing
  with: httplib2.SSLHandshakeError: [SSL: CERTIFICATE_VERIFY_FAILED]
  certificate verify failed (_ssl.c:661)

- An issue discussed on the google-api-python-client github suggests
  upgrading might solve this:
  https://github.com/google/google-api-python-client/issues/453

@schmie