### PR TITLE
Correctly configure the oauth2 flags

### DIFF
--- a/analytics_fetcher/support/auth.py
+++ b/analytics_fetcher/support/auth.py
@@ -127,18 +127,23 @@ def calc_env_var(client_secrets_path):
 
 
 def open_client(afm):
-    """Open an oauth2client.
+    """
+    Open an oauth2client.
 
     :param afm: an AuthFileManager which will be used to lookup the filenames
     needed.
-
     """
-    # Prevent oauth2client from trying to open a browser
-    # This is run from inside the VM so there is no browser
-    oauth2client.tools.FLAGS.auth_local_webserver = False
+
+    # Usually this would be an object that came from
+    # https://github.com/google/oauth2client/blob/master/oauth2client/tools.py#L77
+    # but here we can trick it by passing a class instance with the same attributes.
+    class Flags:
+        logging_level = 'ERROR'
+        noauth_local_webserver = True
 
     return gapy.client.from_secrets_file(
         afm.path("client_secrets.json"),
         storage_path=afm.path("storage.json"),
         readonly=True,
+        flags=Flags(),
     )


### PR DESCRIPTION
In a8dd0c00f726fb1a1fefa513243ead8c433f1444 we updated the version of `oauth2client`. This introduced a different way of specifying the
flags and the old way [was removed](https://github.com/google/oauth2client/commit/05ae3426f271515bab4dc6a210428300286438e8#diff-57fd91e392e1a9696a2348f92e8c87a1). This was updated in [our `gapy` module](https://github.com/alphagov/gapy/commit/d81788bbbed3c17bc5effa8014f77d94639d5b2a#diff-74f1b682017477a92abd84bbdb9a2ded) to support the new `flags` attribute and so we [can now use it](https://github.com/google/oauth2client/blob/master/oauth2client/tools.py#L196) here.

We're having to use a class here to specify the flags because the `run_tools` method (called by `gapy.client.from_secrets_file`) is really expecting an object from `ArgumentParser` but we can instead pass a class with the same attributes.

[Trello Card](https://trello.com/c/ixHjphGn/235-look-into-search-analytics-failed-jenkins-job)