### PR TITLE
Disable job after rummager index incident

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -1,22 +1,24 @@
 #!/bin/bash
-set -e
-set -o pipefail
+echo "Currently disabled because of Rummager index failure"
 
-if [[ -z $TARGET_APPLICATION ]]; then
-  TARGET_APPLICATION=rummager
-fi
-
-SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
-if [[ -z $SKIP_TRAFFIC_LOAD ]]; then
-  if [ \! -d ENV ]; then virtualenv -p /opt/python2.7/bin/python ENV; fi
-  . ENV/bin/activate
-  pip install -r requirements.txt
-  rm -f page-traffic.dump
-  PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
-  ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; govuk_setenv ${TARGET_APPLICATION} bundle exec ./bin/page_traffic_load)" < page-traffic.dump
-  ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:clean RUMMAGER_INDEX=page-traffic)"
-fi
-
-ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"
-ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"
-ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; RUMMAGER_INDEX=govuk govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"
+#set -e
+#set -o pipefail
+#
+#if [[ -z $TARGET_APPLICATION ]]; then
+#  TARGET_APPLICATION=rummager
+#fi
+#
+#SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
+#if [[ -z $SKIP_TRAFFIC_LOAD ]]; then
+#  if [ \! -d ENV ]; then virtualenv -p /opt/python2.7/bin/python ENV; fi
+#  . ENV/bin/activate
+#  pip install -r requirements.txt
+#  rm -f page-traffic.dump
+#  PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
+#  ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; govuk_setenv ${TARGET_APPLICATION} bundle exec ./bin/page_traffic_load)" < page-traffic.dump
+#  ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:clean RUMMAGER_INDEX=page-traffic)"
+#fi
+#
+#ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"
+#ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"
+#ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; RUMMAGER_INDEX=govuk govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"


### PR DESCRIPTION
We are disabling this temporarily while we investigate the incident
involving high memory on redis.