### PR TITLE
Rename the "rummager:" rake tasks and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ the final argument `14` is the number of days to fetch analytics data for.)
 
 This will generate a file called `page-traffic.dump`, which is in elasticsearch
 bulk load format, and can be loaded into the search index using the `bulk_load`
-script in rummager.  This contains information on the amount of traffic each
+script in search-api.  This contains information on the amount of traffic each
 page on GOV.UK got (after some normalisation).
 
 The fetching script fetches data from GA by making requests for each day's

--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -14,19 +14,19 @@ if [[ -z $SKIP_TRAFFIC_LOAD ]]; then
   rm -f page-traffic.dump
   PYTHONPATH=. python scripts/fetch.py page-traffic.dump 14
   ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; govuk_setenv ${TARGET_APPLICATION} bundle exec ./bin/page_traffic_load)" < page-traffic.dump
-  ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:clean RUMMAGER_INDEX=page-traffic)"
+  ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; govuk_setenv ${TARGET_APPLICATION} bundle exec rake search:clean SEARCH_INDEX=page-traffic)"
 fi
 
-ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; PROCESS_ALL_DATA=true RUMMAGER_INDEX=detailed govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"
+ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; PROCESS_ALL_DATA=true SEARCH_INDEX=detailed govuk_setenv ${TARGET_APPLICATION} bundle exec rake search:update_popularity)"
 
 # Wait 40 minutes, to let the Sidekiq jobs be processed to avoid
 # taking up lots of Redis memory
 sleep 2400
 
-ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; PROCESS_ALL_DATA=true RUMMAGER_INDEX=government govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"
+ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; PROCESS_ALL_DATA=true SEARCH_INDEX=government govuk_setenv ${TARGET_APPLICATION} bundle exec rake search:update_popularity)"
 
 # Wait 40 minutes, to let the Sidekiq jobs be processed to avoid
 # taking up lots of Redis memory
 sleep 2400
 
-ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; RUMMAGER_INDEX=govuk govuk_setenv ${TARGET_APPLICATION} bundle exec rake rummager:update_popularity)"
+ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; SEARCH_INDEX=govuk govuk_setenv ${TARGET_APPLICATION} bundle exec rake search:update_popularity)"

--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -3,7 +3,7 @@ set -e
 set -o pipefail
 
 if [[ -z $TARGET_APPLICATION ]]; then
-  TARGET_APPLICATION=rummager
+  TARGET_APPLICATION=search-api
 fi
 
 SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)


### PR DESCRIPTION
Deploy with https://github.com/alphagov/search-api/pull/1532

---

[Trello card](https://trello.com/c/QFqYu8XR/656-%F0%9F%92%80-update-rummager-code-and-documentation-to-refer-only-to-search-api-%F0%9F%92%80)