### PR TITLE
Fix bytes/string confusion with base64

### DIFF
--- a/analytics_fetcher/support/auth.py
+++ b/analytics_fetcher/support/auth.py
@@ -27,7 +27,7 @@ AuthFileManager context is exited.  ie, if the secrets had been passed in the
 
 """
 
-from .utils import base64, to_json
+from .utils import base64_encode, base64_decode, to_json
 import gapy.client
 import json
 import logging
@@ -103,11 +103,11 @@ class AuthFileManager(object):
             [key, self.data(key)]
             for key in list(self.paths.keys())
         ]
-        return base64(zlib.compress(to_json(value), 9))
+        return base64_encode(zlib.compress(to_json(value), 9))
 
     def from_env_var(self, value):
         self._check_entered()
-        for key, value in json.loads(zlib.decompress(value.decode('base64'))):
+        for key, value in json.loads(zlib.decompress(base64_decode(value))):
             self.set_data(key, value)
 
 

--- a/analytics_fetcher/support/utils.py
+++ b/analytics_fetcher/support/utils.py
@@ -1,9 +1,14 @@
+from base64 import b64encode, b64decode
 import json
 
 
-def base64(s):
-    """Convert a string to base64"""
-    return s.encode('base64').replace("\n", "")
+def base64_encode(bs):
+    """Convert bytes to base64"""
+    return b64encode(bs).replace("\n", "")
+
+def base64_decode(s):
+    """Convert an ASCII base64 string to bytes"""
+    return b64decode(s.encode('ascii'))
 
 
 def to_json(obj):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "scripts/fetch.py", line 38, in <module>
    sys.exit(main(sys.argv))
  File "scripts/fetch.py", line 32, in main
    fetch(**options)
  File "/var/lib/jenkins/workspace/search-api-fetch-analytics-data/analytics_fetcher/fetch.py", line 15, in fetch
    with ClientContext(cache_days=30) as client:
  File "/var/lib/jenkins/workspace/search-api-fetch-analytics-data/analytics_fetcher/support/ga_client.py", line 217, in __enter__
    self.afm.from_env_var(os.environ["GAAUTH"])
  File "/var/lib/jenkins/workspace/search-api-fetch-analytics-data/analytics_fetcher/support/auth.py", line 110, in from_env_var
    for key, value in json.loads(zlib.decompress(value.decode('base64'))):
AttributeError: 'str' object has no attribute 'decode'
```

https://deploy.blue.production.govuk.digital/job/search-api-fetch-analytics-data/130/console

---

[Trello card](https://trello.com/c/AsJoR3Dv/906-rewrite-search-analytics-script-in-python-3)