### PR TITLE
Fix docker file permissions

### DIFF
--- a/nightly-run.sh
+++ b/nightly-run.sh
@@ -8,11 +8,12 @@ fi
 
 SEARCH_NODE=$(/usr/local/bin/govuk_node_list -c search --single-node)
 if [[ -z $SKIP_TRAFFIC_LOAD ]]; then
-  docker run --rm -e GAAUTH="$GAAUTH" -v "$(pwd)/:/govuk-search-analytics" python:3.8.0 bash -c """
+  docker run --rm -e GAAUTH="$GAAUTH" -v "$(pwd)/:/govuk-search-analytics" -e CURRENT_USER="$(id -u ${USER})" -e CURRENT_GROUP="$(id -g ${USER})" python:3.8.0 bash -c """
   cd /govuk-search-analytics
   pip install -r requirements.txt
   rm -f page-traffic.dump
   python3 scripts/fetch.py page-traffic.dump 14
+  chown -R "\${CURRENT_USER}:\${CURRENT_GROUP}" .
   """
 
   ssh deploy@${SEARCH_NODE} "(cd /var/apps/${TARGET_APPLICATION}; govuk_setenv ${TARGET_APPLICATION} bundle exec ./bin/page_traffic_load)" < page-traffic.dump


### PR DESCRIPTION
This prevents issues with root-owned directories ending up on the
host.

It would be nice to use user namespace mapping (so root in the
container maps to jenkins on the host), but that requires changing the
dockerd configuration, and probably has ramifications.