### PR TITLE
Add test for `ga.py`

### DIFF
--- a/analytics_fetcher/ga.py
+++ b/analytics_fetcher/ga.py
@@ -27,17 +27,13 @@
 """
 
 
-class GAData(object):
+class GAData():
     """Gets page view data via the Google API"""
     def __init__(self, ga_client, date):
         self.client = ga_client
         self.date = date
         self.date_idstr = date.strftime("%Y%m%d")
-        self.date_str = '%04d-%02d-%02dT00:00:00Z' % (
-            self.date.year,
-            self.date.month,
-            self.date.day,
-        )
+        self.date_str = f'{self.date.year}-{self.date.month:02d}-{self.date.day:02d}T00:00:00Z'
 
     def fetch_traffic_info(self):
         """Fetch info on views of pages.
@@ -50,17 +46,7 @@ class GAData(object):
         """
         not_found_title = 'Page not found - 404 - GOV.UK'
         result = {}
-        for row in self.client.fetch(
-            'search', self.date,
-            metrics='ga:uniquePageViews',
-            dimensions='ga:pagePath,ga:pageTitle',
-            sort='-ga:uniquePageViews',
-            name_map={
-                'uniquePageViews': 'views',
-                'pagePath': 'path',
-                'pageTitle': 'title',
-            },
-        ):
+        for row in self.get_traffic_from_api():
             path = row['path']
             views = row['views']
             title = row['title']
@@ -72,3 +58,19 @@ class GAData(object):
                 item[0] += views
                 item[1] = (item[1] and not_found)
         return result
+
+    def get_traffic_from_api(self):
+        """Searches the Google API for page view data and returns
+            all matching rows.
+        """
+        return self.client.fetch(
+            'search', self.date,
+            metrics='ga:uniquePageViews',
+            dimensions='ga:pagePath,ga:pageTitle',
+            sort='-ga:uniquePageViews',
+            name_map={
+                'uniquePageViews': 'views',
+                'pagePath': 'path',
+                'pageTitle': 'title',
+            },
+        )

--- a/analytics_fetcher/ga.py
+++ b/analytics_fetcher/ga.py
@@ -1,9 +1,34 @@
 """Provide access to google analytics data for search.
 
+    Example data...
+    [
+        {
+            'path': '/fred',
+            'views': 100,
+            'title': 'ignored'
+        },
+        {
+            'path': '/fred',
+            'views': 200,
+            'title': 'ignored'
+        },
+        {
+            'path': '/wilma',
+            'views': 200,
+            'title': 'ignored'
+        }
+    ]
+
+    Result...
+    {
+        '/fred': [300, False],
+        '/wilma': [200, False]
+    }
 """
 
 
 class GAData(object):
+    """Gets page view data via the Google API"""
     def __init__(self, ga_client, date):
         self.client = ga_client
         self.date = date
@@ -19,7 +44,7 @@ class GAData(object):
 
         Returns a dict keyed by path.  Values are a tuple of:
 
-         - total number of views (unique per session)
+         - total number of views (unique per path)
          - boolean: True iff the page consistently returns a not found error.
 
         """

--- a/test/analytics_fetcher/test_ga.py
+++ b/test/analytics_fetcher/test_ga.py
@@ -1,0 +1,59 @@
+import unittest
+import datetime
+from unittest.mock import Mock
+from analytics_fetcher.ga import GAData
+
+
+class TestGa(unittest.TestCase):
+    def setUp(self):
+        self.date = datetime.datetime(2020, 1, 1)
+        self.client = Mock()
+        self.client.fetch = Mock(return_value=[])
+        self.ga_data = GAData(self.client, self.date)
+
+    def test_init(self):
+        self.assertEqual(self.ga_data.client, self.client)
+        self.assertEqual(self.ga_data.date, self.date)
+        self.assertEqual(self.ga_data.date_idstr, "20200101")
+        self.assertEqual(self.ga_data.date_str, "2020-01-01T00:00:00Z")
+
+    def test_fetch_traffic_info_empty(self):
+        expected = {}
+        self.assertEqual(self.ga_data.fetch_traffic_info(), expected)
+
+    def test_fetch_traffic_info_without_any_duplicate_paths(self):
+        self.client.fetch = Mock(return_value=[
+                {
+                    'path': '/fred',
+                    'views': 100,
+                    'title': 'ignored'
+                },
+                {
+                    'path': '/wilma',
+                    'views': 200,
+                    'title': 'ignored'
+                }
+            ]
+        )
+        expected = {
+            '/fred': [100, False],
+            '/wilma': [200, False]
+        }
+        self.assertEqual(self.ga_data.fetch_traffic_info(), expected)
+
+    def test_fetch_traffic_info_with_a_duplicate_path(self):
+        self.client.fetch = Mock(return_value=[
+                {
+                    'path': '/fred',
+                    'views': 100,
+                    'title': 'ignored'
+                },
+                {
+                    'path': '/fred',
+                    'views': 200,
+                    'title': 'ignored'
+                }
+            ]
+        )
+        expected = { '/fred': [300, False] }
+        self.assertEqual(self.ga_data.fetch_traffic_info(), expected)


### PR DESCRIPTION
This change does 3 things:

1. Adds documentation and comments to `ga.py`
2. Adds a test for `ga.py`
3. Fixes `pylint` issues

## Test Coverage 

```bash
(venv) GDS10884:search-analytics grahamlewis$ coverage run -m unittest discover
.............
----------------------------------------------------------------------
Ran 13 tests in 0.003s

OK
(venv) $ coverage report -m
Name                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------
analytics_fetcher/__init__.py                 0      0   100%
analytics_fetcher/analysis.py                21      0   100%
analytics_fetcher/ga.py                      20      0   100%
analytics_fetcher/support/__init__.py         0      0   100%
gapy/__init__.py                              3      0   100%
test/__init__.py                              0      0   100%
test/analytics_fetcher/__init__.py            0      0   100%
test/analytics_fetcher/test_analysis.py      28      0   100%
test/analytics_fetcher/test_ga.py            26      0   100%
-----------------------------------------------------------------------
TOTAL                                        98      0   100%
```

## Pre-lint fix

```bash
(venv) $ pylint ./analytics_fetcher/ga.py
************* Module analytics_fetcher.ga
analytics_fetcher/ga.py:30:0: R0205: Class 'GAData' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
analytics_fetcher/ga.py:36:24: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
analytics_fetcher/ga.py:30:0: R0903: Too few public methods (1/2) (too-few-public-methods)

------------------------------------------------------------------
Your code has been rated at 8.50/10 (previous run: 8.50/10, +0.00)
```

## Post-lint fix

```bash
(venv) $ pylint ./analytics_fetcher/ga.py

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

## Post-lint test coverage

```bash
(venv) $ coverage report -m
Name                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------
analytics_fetcher/__init__.py                 0      0   100%
analytics_fetcher/analysis.py                21      0   100%
analytics_fetcher/ga.py                      22      0   100%
analytics_fetcher/support/__init__.py         0      0   100%
gapy/__init__.py                              3      0   100%
test/__init__.py                              0      0   100%
test/analytics_fetcher/__init__.py            0      0   100%
test/analytics_fetcher/test_analysis.py      28      0   100%
test/analytics_fetcher/test_ga.py            26      0   100%
-----------------------------------------------------------------------
TOTAL                                       100      0   100%
```

[Trello](https://trello.com/c/l2apQj0o/228-fix-search-analytics-dependabot-issues)
