### PR TITLE
Add GitHub Action to run night export

### DIFF
--- a/.github/workflows/export-anayltics.yml
+++ b/.github/workflows/export-anayltics.yml
@@ -1,0 +1,31 @@
+name: "Review users"
+
+on:
+  schedule:
+    - cron:  '5 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  review-users:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run analytics export script
+        env:
+          GAAUTH: ${{ secrets.GAAUTH }}
+        run: "python scripts/fetch.py page-traffic.dump 14"


### PR DESCRIPTION
This is the initial workflow to run the nightly export. This workflow will need to be expanded to upload the file to S3. Which then can be retrieved by the search-api to update the relevancy ratings.