### PR TITLE
Add steps to copy analytics to S3

### DIFF
--- a/.github/workflows/export-anayltics.yml
+++ b/.github/workflows/export-anayltics.yml
@@ -29,3 +29,13 @@ jobs:
         env:
           GAAUTH: ${{ secrets.GAAUTH }}
         run: "python scripts/fetch.py page-traffic.dump 14"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::172025368201:role/search_analytics_github_action_role
+          aws-region: eu-west-1
+
+      - name: Copy analytics to S3
+        run: |
+          aws s3 cp page-traffic.dump s3://govuk-search-analytics-production/page-traffic.dump

--- a/.github/workflows/export-anayltics.yml
+++ b/.github/workflows/export-anayltics.yml
@@ -1,4 +1,4 @@
-name: "Review users"
+name: "Export analytics"
 
 on:
   schedule:
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  review-users:
+  export-analytics:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This copies the analytics file to S3 to be ingested by search-api.

(Also fixes the workflow name)
