### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
This project is very dangerous to update dependencies on as there is no CI and no alerting when it breaks. It seems most prudent to remove dependabot and stop being updated.

The useful life of this project is coming to an end with the sunset of Universal Analytics so there's a confidence that these dependencies won't be used for long.